### PR TITLE
RDM updates (#428)

### DIFF
--- a/Magitek/Logic/BlackMage/Aoe.cs
+++ b/Magitek/Logic/BlackMage/Aoe.cs
@@ -21,6 +21,9 @@ namespace Magitek.Logic.BlackMage
             if (Core.Me.ClassLevel < 70)
                 return false;
 
+            if (Casting.LastSpell == Spells.Foul)
+                return false;
+            
             // If we need to refresh stack timer, stop
             if (ActionResourceManager.BlackMage.StackTimer.TotalMilliseconds <= 5000)
                 return false;
@@ -56,9 +59,20 @@ namespace Magitek.Logic.BlackMage
                 return false;            
 
             //If we have Umbral hearts, Freeze has gone off
-            if (ActionResourceManager.BlackMage.UmbralHearts >= 1)
+            //Trying logic from xeno instead to see if this allows T4 to go off
+            /*if (ActionResourceManager.BlackMage.UmbralHearts >= 1)
                 if (Casting.LastSpell != Spells.Foul)
                     return await Spells.Foul.Cast(Core.Me.CurrentTarget);
+            */
+            //If while in Umbral 3 and, we didn't use Thunder in the Umbral window
+            if (ActionResourceManager.BlackMage.UmbralStacks == 3 && Casting.LastSpell != Spells.Thunder4)
+            {
+                //We don't have max mana
+                if (Core.Me.CurrentMana < 10000 && Core.Me.CurrentTarget.HasAura(Auras.Thunder4, true, 5000))
+                    return await Spells.Foul.Cast(Core.Me.CurrentTarget);
+
+                return await Spells.Thunder4.Cast(Core.Me.CurrentTarget);
+            }
 
             return false;
         }

--- a/Magitek/Logic/RedMage/Aoe.cs
+++ b/Magitek/Logic/RedMage/Aoe.cs
@@ -41,6 +41,9 @@ namespace Magitek.Logic.RedMage
             if (!RedMageSettings.Instance.UseAoe)
                 return false;
 
+            if (!RedMageSettings.Instance.UseContreSixte)
+                return false;
+
             if (Core.Me.ClassLevel < Spells.ContreSixte.LevelAcquired)
                 return false;
 

--- a/Magitek/Logic/RedMage/SingleTarget.cs
+++ b/Magitek/Logic/RedMage/SingleTarget.cs
@@ -21,6 +21,11 @@ namespace Magitek.Logic.RedMage
             if (InAoeCombo())
                 return false;
 
+            if (Core.Me.HasAura(Auras.Swiftcast)
+                || Core.Me.HasAura(Auras.Dualcast)
+                || Core.Me.HasAura(Auras.Acceleration))
+                return false;
+
             //If embolden coming off cd soon, wait
             if (Core.Me.ClassLevel >= Spells.Embolden.LevelAcquired
                 && Spells.Embolden.Cooldown.Seconds <= 10)
@@ -461,10 +466,16 @@ namespace Magitek.Logic.RedMage
             if (Core.Me.ClassLevel < Spells.CorpsACorps.LevelAcquired)
                 return false;
 
+            if (Core.Me.HasAura(Auras.Swiftcast)
+                || Core.Me.HasAura(Auras.Dualcast)
+                || Core.Me.HasAura(Auras.Acceleration))
+                return false;
+
             if (InAoeCombo())
                 return false;
 
-            if (Core.Me.CurrentTarget.Distance() <= 3)
+            if (Core.Me.CurrentTarget.Distance() <= 3
+                && !RedMageSettings.Instance.CorpsACorpsInMeleeRangeOnly)
                 return false;
 
             if (InCombo())


### PR DESCRIPTION
* RDM update

Added logic to use manafication below or at 30 mana if embolden is almost off cd

* RDM update

Added some missing toggle settings
Added check for dual/swiftcast and accel into melee combo and gap closer

* BLM update

Finally T4 will go off reliably in AoE situations